### PR TITLE
support for belongs_to with custom source

### DIFF
--- a/lib/schema_assertions.ex
+++ b/lib/schema_assertions.ex
@@ -30,10 +30,14 @@ defmodule SchemaAssertions do
       iex> alias SchemaAssertions.Test.Schema
       iex> SchemaAssertions.assert_belongs_to(Schema.Room, :house, Schema.House)
       true
+
+      iex> alias SchemaAssertions.Test.Schema
+      iex> SchemaAssertions.assert_belongs_to(Schema.Pet, :home, Schema.House, source: :house_id)
+      true
   """
-  @spec assert_belongs_to(module(), atom(), module()) :: true
-  def assert_belongs_to(schema_module, association, association_module) do
-    case Schema.belongs_to?(schema_module, association, association_module) do
+  @spec assert_belongs_to(module(), atom(), module(), Keyword.t()) :: true
+  def assert_belongs_to(schema_module, association, association_module, opts \\ []) do
+    case Schema.belongs_to?(schema_module, association, association_module, opts) do
       :ok ->
         true
 

--- a/priv/repo/migrations/20240222053504_add_home_id_to_pets.exs
+++ b/priv/repo/migrations/20240222053504_add_home_id_to_pets.exs
@@ -1,0 +1,9 @@
+defmodule SchemaAssertions.Test.Repo.Migrations.AddHomeIdToPets do
+  use Ecto.Migration
+
+  def change do
+    alter table(:pets) do
+      add(:house_id, references(:houses))
+    end
+  end
+end

--- a/test/schema_assertions/database_test.exs
+++ b/test/schema_assertions/database_test.exs
@@ -24,6 +24,7 @@ defmodule SchemaAssertions.DatabaseTest do
                favorite_numbers: {:array, :integer},
                feet_count: :integer,
                friendly: :boolean,
+               house_id: :bigint,
                id: :uuid,
                last_seen_vet: :utc_datetime,
                last_seen_vet_usec: :utc_datetime_usec,

--- a/test/schema_assertions/schema_test.exs
+++ b/test/schema_assertions/schema_test.exs
@@ -18,9 +18,23 @@ defmodule SchemaAssertions.SchemaTest do
       assert :ok = Schema.belongs_to?(Test.Schema.Room, :house, Test.Schema.House)
     end
 
+    test "returns :ok when the schema has a belongs_to relationship with matching :source" do
+      assert :ok = Schema.belongs_to?(Test.Schema.Pet, :home, Test.Schema.House, source: :house_id)
+    end
+
     test "returns error when the associated module does not match" do
       assert {:error, "Found module: Elixir.SchemaAssertions.Test.Schema.House"} =
                Schema.belongs_to?(Test.Schema.Room, :house, Test.Schema.Window)
+    end
+
+    test "returns error when the :source is incorrect" do
+      assert {:error, "home_id does not exist in table"} =
+               Schema.belongs_to?(Test.Schema.Pet, :home, Test.Schema.House, source: :residence_id)
+    end
+
+    test "returns error when no :source option provided for a schema with a custom source" do
+      assert {:error, "home_id does not exist in table"} =
+               Schema.belongs_to?(Test.Schema.Pet, :home, Test.Schema.House)
     end
 
     test "returns error when the schema does not have a belongs_to relationship" do

--- a/test/schema_assertions/schema_test.exs
+++ b/test/schema_assertions/schema_test.exs
@@ -14,7 +14,7 @@ defmodule SchemaAssertions.SchemaTest do
   end
 
   describe "belongs_to?" do
-    test "returns :ok when the schema has a has_many relationship" do
+    test "returns :ok when the schema has a belongs_to relationship" do
       assert :ok = Schema.belongs_to?(Test.Schema.Room, :house, Test.Schema.House)
     end
 

--- a/test/schema_assertions_test.exs
+++ b/test/schema_assertions_test.exs
@@ -145,14 +145,15 @@ defmodule SchemaAssertionsTest do
                          dob: :naive_datetime_usec,
                          dob_usec: :naive_datetime,
                          nickname: :string,
-                         teeth_count: :bigint
+                         teeth_count: :bigint,
+                         house_id: :bigint
                        )
                      end
 
       msg = Exception.message(error)
 
       assert msg |> strip_ansi() ==
-               "\n\nExpected fields to match database\n\n     Expected:\n       [\n         dob: :naive_datetime_usec\n         dob_usec: :naive_datetime\n         feet_count: :integer\n         friendly: :boolean\n         id: :uuid\n         last_seen_vet: :utc_datetime_usec\n         last_seen_vet_usec: :utc_datetime\n         nickname: :string\n         teeth_count: :bigint\n       ]\n\n     Actual:\n       [\n         dob: :utc_datetime\n         dob_usec: :utc_datetime_usec\n         favorite_numbers: {:array, :integer}\n         feet_count: :integer\n         friendly: :boolean\n         id: :uuid\n         last_seen_vet: :utc_datetime\n         last_seen_vet_usec: :utc_datetime_usec\n         nickname: :string\n         teeth_count: :bigint\n         toys: {:array, :string}\n       ]\n"
+               "\n\nExpected fields to match database\n\n     Expected:\n       [\n         dob: :naive_datetime_usec\n         dob_usec: :naive_datetime\n         feet_count: :integer\n         friendly: :boolean\n         house_id: :bigint\n         id: :uuid\n         last_seen_vet: :utc_datetime_usec\n         last_seen_vet_usec: :utc_datetime\n         nickname: :string\n         teeth_count: :bigint\n       ]\n\n     Actual:\n       [\n         dob: :utc_datetime\n         dob_usec: :utc_datetime_usec\n         favorite_numbers: {:array, :integer}\n         feet_count: :integer\n         friendly: :boolean\n         house_id: :bigint\n         id: :uuid\n         last_seen_vet: :utc_datetime\n         last_seen_vet_usec: :utc_datetime_usec\n         nickname: :string\n         teeth_count: :bigint\n         toys: {:array, :string}\n       ]\n"
     end
 
     test "passes when low-precision datetimes are correctly compared with high-precision datetimes" do
@@ -167,7 +168,8 @@ defmodule SchemaAssertionsTest do
         dob_usec: :naive_datetime_usec,
         nickname: :string,
         teeth_count: :bigint,
-        toys: {:array, :string}
+        toys: {:array, :string},
+        house_id: :bigint
       )
     end
   end

--- a/test/support/schema/pet.ex
+++ b/test/support/schema/pet.ex
@@ -11,5 +11,7 @@ defmodule SchemaAssertions.Test.Schema.Pet do
     field :dob_usec, :naive_datetime
     field :nickname, :string
     field :teeth_count, :integer
+
+    belongs_to :home, SchemaAssertions.Test.Schema.House, source: :house_id
   end
 end


### PR DESCRIPTION
Leverages [Ecto.Schema reflection](https://hexdocs.pm/ecto/Ecto.Schema.html#module-reflection) to match the source/alias:

> - `__schema__(:field_source, field)` - Returns the alias of the given field;

fixes #4 