### PR TITLE
Add support for materialized table views (PostgreSQL)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased changes
 
+- Verify support for table views (PostgreSQL)
+
 ## v1.0.0
 
 - Verify support for Elixir 1.17.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased changes
 
 - Verify support for table views (PostgreSQL)
+- Add support for materialized table views (PostgreSQL)
 
 ## v1.0.0
 

--- a/lib/schema_assertions/database.ex
+++ b/lib/schema_assertions/database.ex
@@ -8,7 +8,25 @@ defmodule SchemaAssertions.Database do
   @doc "Returns a sorted list of all the table names"
   @spec all_table_names() :: [binary()]
   def all_table_names do
-    "select table_name from information_schema.tables where table_schema = 'public'"
+    all_tables_and_views_statement = """
+    SELECT
+      table_name
+    FROM
+      information_schema.tables
+    WHERE
+      table_schema = 'public'
+    """
+
+    all_materialized_views_statement = """
+    SELECT
+      matviewname AS table_name
+    FROM
+      pg_matviews
+    WHERE
+      schemaname = 'public'
+    """
+
+    "#{all_tables_and_views_statement} UNION #{all_materialized_views_statement}"
     |> query()
     |> List.flatten()
     |> Enum.sort()

--- a/priv/repo/migrations/20240813045123_create_house_addresses_view.exs
+++ b/priv/repo/migrations/20240813045123_create_house_addresses_view.exs
@@ -1,0 +1,21 @@
+defmodule SchemaAssertions.Test.Repo.Migrations.CreateHouseAddressesView do
+  use Ecto.Migration
+
+  @view_name "house_addresses"
+
+  def change do
+    execute(
+      """
+      CREATE VIEW #{@view_name} AS (
+      SELECT
+        address AS address,
+        id AS house_id
+      FROM houses
+      )
+      """,
+      """
+      DROP VIEW #{@view_name}
+      """
+    )
+  end
+end

--- a/priv/repo/migrations/20240813050031_create_materialized_house_addresses.exs
+++ b/priv/repo/migrations/20240813050031_create_materialized_house_addresses.exs
@@ -1,0 +1,21 @@
+defmodule SchemaAssertions.Test.Repo.Migrations.CreateMaterializedHouseAddresses do
+  use Ecto.Migration
+
+  @materialized_view_name "materialized_house_addresses"
+
+  def change do
+    execute(
+      """
+      CREATE MATERIALIZED VIEW #{@materialized_view_name} AS (
+      SELECT
+        address AS address,
+        house_id AS house_id
+      FROM house_addresses
+      )
+      """,
+      """
+      DROP MATERIALIZED VIEW #{@materialized_view_name}
+      """
+    )
+  end
+end

--- a/test/schema_assertions/database_test.exs
+++ b/test/schema_assertions/database_test.exs
@@ -5,7 +5,14 @@ defmodule SchemaAssertions.DatabaseTest do
 
   describe "all_table_names" do
     test "lists all the table names, in alphabetical order" do
-      assert Database.all_table_names() == ["cars", "houses", "pets", "rooms", "schema_migrations"]
+      assert Database.all_table_names() == [
+               "cars",
+               "house_addresses",
+               "houses",
+               "pets",
+               "rooms",
+               "schema_migrations"
+             ]
     end
   end
 
@@ -14,6 +21,13 @@ defmodule SchemaAssertions.DatabaseTest do
       assert Database.fieldset("houses") == [
                address: :text,
                id: :bigserial
+             ]
+    end
+
+    test "translates columns for a view into a keyword list of fields, in alphabetical order" do
+      assert Database.fieldset("house_addresses") == [
+               address: :text,
+               house_id: :bigint
              ]
     end
 

--- a/test/schema_assertions/database_test.exs
+++ b/test/schema_assertions/database_test.exs
@@ -9,6 +9,7 @@ defmodule SchemaAssertions.DatabaseTest do
                "cars",
                "house_addresses",
                "houses",
+               "materialized_house_addresses",
                "pets",
                "rooms",
                "schema_migrations"
@@ -26,6 +27,13 @@ defmodule SchemaAssertions.DatabaseTest do
 
     test "translates columns for a view into a keyword list of fields, in alphabetical order" do
       assert Database.fieldset("house_addresses") == [
+               address: :text,
+               house_id: :bigint
+             ]
+    end
+
+    test "translates columns for a materialized view into a keyword list of fields, in alphabetical order" do
+      assert Database.fieldset("materialized_house_addresses") == [
                address: :text,
                house_id: :bigint
              ]

--- a/test/schema_assertions_test.exs
+++ b/test/schema_assertions_test.exs
@@ -17,6 +17,10 @@ defmodule SchemaAssertionsTest do
       SchemaAssertions.assert_belongs_to(Schema.HouseAddress, :house, Schema.House)
     end
 
+    test "succeeds when the schema is a materialized view with a relationship according the function args" do
+      SchemaAssertions.assert_belongs_to(Schema.MaterializedHouseAddress, :house, Schema.House)
+    end
+
     test "fails when no association exists" do
       assert_raise ExUnit.AssertionError,
                    """
@@ -122,7 +126,7 @@ defmodule SchemaAssertionsTest do
 
     test "fails when the table does not exist" do
       assert_raise ExUnit.AssertionError,
-                   ~s|\n\nDatabase table "non_existent_table_name" not found in ["cars", "house_addresses", "houses", "pets", "rooms", "schema_migrations"]\n|,
+                   ~s|\n\nDatabase table "non_existent_table_name" not found in ["cars", "house_addresses", "houses", "materialized_house_addresses", "pets", "rooms", "schema_migrations"]\n|,
                    fn ->
                      SchemaAssertions.assert_schema(SchemaAssertions.Test.Schema.House, "non_existent_table_name")
                    end

--- a/test/schema_assertions_test.exs
+++ b/test/schema_assertions_test.exs
@@ -13,6 +13,10 @@ defmodule SchemaAssertionsTest do
       SchemaAssertions.assert_belongs_to(Schema.Room, :house, Schema.House)
     end
 
+    test "succeeds when the schema is a view with a relationship according the function args" do
+      SchemaAssertions.assert_belongs_to(Schema.HouseAddress, :house, Schema.House)
+    end
+
     test "fails when no association exists" do
       assert_raise ExUnit.AssertionError,
                    """
@@ -118,7 +122,7 @@ defmodule SchemaAssertionsTest do
 
     test "fails when the table does not exist" do
       assert_raise ExUnit.AssertionError,
-                   ~s|\n\nDatabase table "non_existent_table_name" not found in ["cars", "houses", "pets", "rooms", "schema_migrations"]\n|,
+                   ~s|\n\nDatabase table "non_existent_table_name" not found in ["cars", "house_addresses", "houses", "pets", "rooms", "schema_migrations"]\n|,
                    fn ->
                      SchemaAssertions.assert_schema(SchemaAssertions.Test.Schema.House, "non_existent_table_name")
                    end

--- a/test/support/schema/house_address.ex
+++ b/test/support/schema/house_address.ex
@@ -1,0 +1,10 @@
+defmodule SchemaAssertions.Test.Schema.HouseAddress do
+  @moduledoc false
+  use Ecto.Schema
+
+  schema "house_addresses" do
+    field :address, :string
+
+    belongs_to :house, SchemaAssertions.Test.Schema.House
+  end
+end

--- a/test/support/schema/materialized_house_address.ex
+++ b/test/support/schema/materialized_house_address.ex
@@ -1,0 +1,10 @@
+defmodule SchemaAssertions.Test.Schema.MaterializedHouseAddress do
+  @moduledoc false
+  use Ecto.Schema
+
+  schema "materialized_house_addresses" do
+    field :address, :string
+
+    belongs_to :house, SchemaAssertions.Test.Schema.House
+  end
+end


### PR DESCRIPTION
The query used in `Database.all_table_names/0` includes table views, but not materialized table views. This is fixed with a [PostgreSQL `UNION`](https://www.postgresql.org/docs/current/queries-union.html#QUERIES-UNION), using the following query to find materialized view names:

```sql
SELECT
  matviewname AS table_name
FROM
  pg_matviews
WHERE
  schemaname = 'public'
```